### PR TITLE
fix numerous dereference issues, added support for "unknown attacker"…

### DIFF
--- a/scripts/formapp.js
+++ b/scripts/formapp.js
@@ -43,7 +43,6 @@ class DamageTrackerSettings extends FormApplication {
       this._listenersActivated = true;
       this._pollInterval = setInterval(() => {
         if (this.rendered) this.render(false);
-        console.log("render");
       },7000);
     };
 
@@ -120,7 +119,7 @@ class DamageTrackerSettings extends FormApplication {
   close() {
     clearInterval(this._pollInterval);
     super.close();
-    console.log(MODULE_ID, "| removed timer, closed activelisteners");
+    if (isDebug) console.log(MODULE_ID, "| removed FormApplication timer, closed activelisteners");
   }
 
 }


### PR DESCRIPTION
"<Unidentified source>" is used for manually applied damage and any other sources of damage that don't have an origin from PF2e Toolbelt (unarmed attacks being the most prominent that I'm aware of).

also removed an overactive console.log message and hid another behind "if (isDebug)".