### PR TITLE
Grab actual Damage Rolls, Switch to createChatMessage and updateChatMessage instead of preCreate and preUpdate.

### DIFF
--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -13,6 +13,7 @@ Hooks.once("init", () => {
     scope: "world",
     config: true,
     type: Boolean,
+    requiresReload: false,
     default: true
   });
 
@@ -22,6 +23,7 @@ Hooks.once("init", () => {
     scope: "client",
     config: true,
     type: Boolean,
+    requiresReload: false,
     default: false
   });
 


### PR DESCRIPTION
There's no need to hook the pre-* messages since I'm not changing the message contents and there might still be evaluation happening on damage rolls.

Added support in createChatMessage hook for evaluating damage rolls and saving them.

Changed the 2 settings I'm exposing to not require reload on save (I'm reading them whenever I'm deciding what to do anyway).  