### PR TITLE
Support Revert better (previous max values), change export to CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Foundry Virtual Tabletop framework module for tracking biggest hits and cumulati
 ![DamageTracker Settings page](assets/settings.webp)
 
 2 settings on this page:
-1. NPC Damage Tracking determines whether you want to save NPC data in DamageTracker.  If you want PCs only, turn this off.
-2. Debug Logging - this results in significanlty more "DamageTraacker |" messages in the debug console.
+1. NPC Damage Tracking determines whether you want to save NPC data in Damage Tracker.  If you want PCs only, turn this off.
+2. Debug Logging - this results in significanlty more "damage-tracker |" messages in the debug console.
 
-Clicking on the [Details] button will bring up the primary UI for DamageTracker:
+Clicking on the [Details] button will bring up the primary UI for Damage Tracker:
 
 # DamageTracker Details
 ![DamageTracker Details page](assets/details.webp)
@@ -18,7 +18,7 @@ Clicking on the [Details] button will bring up the primary UI for DamageTracker:
 The buttons do what you'd expect:
 - [Clear Tracking Data] will delete all tracking data.
 - [Clear NPC Tracking Data] will delete any NPC data.  
-- [Export Damage Data] will produce a copyable HTML doc.  If you save this as a .html file and open in a browser, you'll get a similar looking table. This allows you to periodically clear the data (or see NPC data) before clearing it.
+- [Export Damage Data] will produce a copyable CSV doc. 
 
 # Terminology
 Description of the different columns:
@@ -29,7 +29,7 @@ Description of the different columns:
 # Usage Details
 There are a couple ways you can use this module, both are basically for vanity/bragging rights for your players (or you if you're a malicious sort of GM).
 
- 1. Use it to feed a dashboard for the players.  I previously had something where I'd analyze the log files to keep track of 
+ 1. Use it to feed a "Player Home" scene.  I previously had something where I'd analyze the log files to keep track of: 
       - Biggest Hitter: (PC who's done the most damage in a single strike)
       - Biggest Hittee: (PC who took the biggest hit)
       - Most Lethal:    (Enemy who did the most cumulative damage)
@@ -40,9 +40,10 @@ There are a couple ways you can use this module, both are basically for vanity/b
       Using these you could build a "Player Home" screen.
   
   2. A curiousity for anyone interested.
-      Damage Tracker is viewable by players as well.  This is a good reason to disable NPC tracking (i.e. just track PC damages).
+      Damage Tracker Details are viewable by players as well.  
+      - Disable NPC tracking to just see Player info.
       - Over the course of a campaign, people might like to know how much damage they've done.  
-      - You could take snapshots (using the Export button) at each milestone of your campaign.
+      - You could take snapshots (using the Export button) at each milestone of your campaign (whether you're tracking PCs or NPCs also)
       - Through careful enabling/disabling of tracking NPCs, you could exclude all but the most pivotal battles - this is why disabling NPC tracking doesn't clear the NPCs from the list.
 
 ## A word or two about the different stats:
@@ -53,8 +54,8 @@ There are a couple ways you can use this module, both are basically for vanity/b
 
   Damage reverting will cancel the whole damage.
   - Subtract from Total Damage.
-  - Clear your Max Roll and Max Hit if it was the largest you had.
-  - I will probably implement a "previous max" strategy in code to avoid setting it to 0, but I'm not going to keep track of all your rolls.
+  - Set your Max Roll and Max Hit to the previous max for either (if the reverted damage was a max for either/both).
+  - Note: Damage Tracker only keeps one "previous max".  If you revert two maxes without setting a new one, the max will reset to 0.
 
 
 

--- a/scripts/damagetracker.js
+++ b/scripts/damagetracker.js
@@ -165,9 +165,16 @@ async function StashDamageRoll(key, name, isNPC, damageRoll) {
 
 function checkAndUpdateMaxDmgRoll(actor,damageRoll) {
   let currentMax = (actor.maxDmgRoll)?actor.maxDmgRoll:0;
+  
   if (damageRoll > currentMax) {
     actor.prevMaxDmgRoll = currentMax;
     actor.maxDmgRoll = damageRoll;
+  } else {
+    // if the roll isn't bigger than the current max, but previous max is zero, update previous max.
+    // This will mostly likely occur due to a revert (that set previous max to 0).
+    if (actor.prevMaxDmgRoll==0) {
+      actor.prevMaxDmgRoll = damageRoll;
+    }
   }
 }
 
@@ -176,6 +183,12 @@ function checkAndUpdateMaxDmg(actor,damage) {
   if (damage > currentMax) {
     actor.prevMaxDmg = currentMax;
     actor.maxDmg = damage;
+   } else {
+    // if the damage isn't bigger than the current max, but previous max is zero, update previous max.
+    // This will mostly likely occur due to a revert (that set previous max to 0).
+    if (actor.prevMaxDmg==0) {
+      actor.prevMaxDmg = damage;
+    }
   }
 }
       

--- a/scripts/damagetracker.js
+++ b/scripts/damagetracker.js
@@ -149,20 +149,35 @@ async function StashDamageRoll(key, name, isNPC, damageRoll) {
     actorMap[key].name = name;
     actorMap[key].isNPC = isNPC;
     actorMap[key].maxDmgRoll = damageRoll;
+    actorMap[key].prevMaxDmgRoll = 0;
 
     if (isDebug) console.log(MODULE_ID, "|", "Created new", (isNPC)?"NPC":"PC", "for:", name, "with", damageRoll, "damage.");
   }
   else {
     const existing = actorMap[key];
-    actorMap[key].maxDmgRoll = Math.max(existing.maxDmgRoll, damageRoll);
-  
+    checkAndUpdateMaxDmgRoll(existing,damageRoll);
+   
     if (isDebug) console.log(MODULE_ID, "|", "Merged data into existing", (isNPC)?"NPC":"PC", "for:", existing.name, "with", damageRoll, "damage.");
   }
 
   await game.settings.set(MODULE_ID, "damageMap", actorMap);
 }
 
+function checkAndUpdateMaxDmgRoll(actor,damageRoll) {
+  let currentMax = (actor.maxDmgRoll)?actor.maxDmgRoll:0;
+  if (damageRoll > currentMax) {
+    actor.prevMaxDmgRoll = currentMax;
+    actor.maxDmgRoll = damageRoll;
+  }
+}
 
+function checkAndUpdateMaxDmg(actor,damage) {
+  let currentMax = (actor.maxDmg)?actor.maxDmg:0;
+  if (damage > currentMax) {
+    actor.prevMaxDmg = currentMax;
+    actor.maxDmg = damage;
+  }
+}
       
 async function AddOrMergeActor(key, name, isNPC, damageRoll, damage) {
   const actorMap = game.settings.get(MODULE_ID, "damageMap") ?? {};
@@ -172,7 +187,9 @@ async function AddOrMergeActor(key, name, isNPC, damageRoll, damage) {
     actorMap[key].name = name;
     actorMap[key].isNPC = isNPC;
     actorMap[key].maxDmgRoll = damageRoll;
+    actorMap[key].prevMaxDmgRoll = 0;
     actorMap[key].maxDmg = damage;
+    actorMap[key].prevMaxDmg = 0;
     actorMap[key].totDmg = damage;
 
     const Actortype = (isNPC)?"NPC":"PC";
@@ -180,18 +197,19 @@ async function AddOrMergeActor(key, name, isNPC, damageRoll, damage) {
     if (isDebug) console.log(MODULE_ID, "|", "Created new", (isNPC)?"NPC":"PC", "for:", name, "with", damage, "damage.");
   } 
   else {    //actor already exists, update
-    const existing = actorMap[key];
-    const Actortype = (existing.isNPC)?"NPC":"PC";
+    const actor = actorMap[key];
+    const Actortype = (actor.isNPC)?"NPC":"PC";
     
     let absMaxDmg = Math.max(damageRoll,damage);  //if damage is > damageRoll, use that.. 
 
-    actorMap[key].maxDmgRoll = Math.max(existing.maxDmgRoll,absMaxDmg);
+    checkAndUpdateMaxDmgRoll(actor,absMaxDmg);
         
     //existing maxDmg and totDmg could be NaN - it's not added by StashDamageRoll
-    actorMap[key].maxDmg = (existing.maxDmg)?Math.max(existing.maxDmg, damage):damage;
-    actorMap[key].totDmg = (existing.totDmg)?existing?.totDmg + damage:damage;
+    checkAndUpdateMaxDmg(actor,damage);
+
+    actor.totDmg = (actor.totDmg)?actor.totDmg + damage:damage;
     
-    if (isDebug) console.log(MODULE_ID, "|", "Merged data into existing", (isNPC)?"NPC":"PC", "for:", existing.name, "with", damage, "damage.");
+    if (isDebug) console.log(MODULE_ID, "|", "Merged data into existing", (isNPC)?"NPC":"PC", "for:", actor.name, "with", damage, "damage.");
   }
   await game.settings.set(MODULE_ID, "damageMap", actorMap);
 }
@@ -199,24 +217,29 @@ async function AddOrMergeActor(key, name, isNPC, damageRoll, damage) {
 async function RevertDamage(key, damageRoll, damage) {
   const actorMap = game.settings.get(MODULE_ID, "damageMap") ?? {};
     
-  if (!actorMap[key]) {   //create new actor in damageMap
+  if (!actorMap[key]) {  
     if (isDebug) console.log(MODULE_ID, "|", "Actor is not in the table to revert damage from");
   } 
   else {    //actor already exists, update
-    const existing = actorMap[key];
-    const Actortype = (existing.isNPC)?"NPC":"PC";
+    const actor = actorMap[key];
+    const Actortype = (actor.isNPC)?"NPC":"PC";
     
-    if (actorMap[key].maxDmgRoll = damageRoll) {
-      actorMap[key].maxDmgRoll = 0;
+    if (actor.maxDmgRoll == damageRoll) {
+      actor.maxDmgRoll = actor.prevMaxDmgRoll;
+      actor.prevMaxDmgRoll = 0;     //don't save the current or it could never revert that roll.  Shouldn't happen, but just in case.
+
     }    
     
-    if (actorMap[key].maxDmg = damage) {
-      actorMap[key].maxDmg = 0;
+    if (actor.maxDmg == damage) {
+      actor.maxDmg = actor.prevMaxDmg;
+      actor.prevMaxDmg = 0;     //don't save the current or it could never revert that roll.  Shouldn't happen, but just in case.
     }
 
-    actorMap[key].totDmg = existing.totDmg - damage;
+    actor.totDmg += -damage;
 
-    if (isDebug) console.log(MODULE_ID, "|", "Reverted damage from existing", (existing.isNPC)?"NPC":"PC", "for:", existing.name, "with", damage, "damage.");
+    if (isDebug) console.log(MODULE_ID, "|", "Reverted damage from existing", (actor.isNPC)?"NPC":"PC", "for:", actor.name, "with", damage, "damage.");
+  
+    await game.settings.set(MODULE_ID, "damageMap", actorMap);
   }
-  await game.settings.set(MODULE_ID, "damageMap", actorMap);
+  
 }

--- a/scripts/formapp.js
+++ b/scripts/formapp.js
@@ -94,18 +94,16 @@ class DamageTrackerSettings extends FormApplication {
     });
 
     html.find(".export-damage-map").click(() => {
-      var exportData = "<!DOCTYPE html><html><body><table><th padding: 10px 20px;>Actor Name</th><th padding: 10px 20px;>Max Damage Roll</th><th padding: 10px 20px;>Max Damage</th><th padding: 10px 20px;>Total Damage</th>";
+      var exportData = "Actor Name, isNPC, Max Damage Roll, Max Damage, Total Damage\n";
       const dmgMap = game.settings.get(MODULE_ID,"damageMap");
       const sortedActors = Object.values(dmgMap).sort((a,b) => b.totDmg - a.totDmg);
 
       sortedActors.forEach(actor => {
-        exportData += `<tr><td>${actor.name}</td><td style="vertical-align: middle;">${actor.maxDmgRoll}</td><td style=style= vertical-align: middle;">${actor.maxDmg}</td><td style= vertical-align: middle;">${actor.totDmg}</td></tr>`;
+        exportData += `${actor.name}, ${actor.isNPC}, ${actor.maxDmgRoll}, ${actor.maxDmg}, ${actor.totDmg}\n`;
       });
 
-      exportData += `</table></body></html>`;
-
       new Dialog({
-        title: "Export Damage Data",
+        title: "Export Damage Data (CSV)",
         content: `<textarea readonly style="width:100%; height:300px;">${exportData}</textarea>`,
         buttons: {
           close: {


### PR DESCRIPTION
Revert now falls back to a "previous Max value" and sets previous to 0.

Previous max is updated (if it's set to 0) by any rolls that are made (even if they aren't new maxes) to more gracefully handle if a "previous max" is cleared after clearing the current max.

