### PR TITLE
Allow sorting of Details list, use Token.name instead of Actor.name for "normal" cases.

### DIFF
--- a/scripts/damagetracker.js
+++ b/scripts/damagetracker.js
@@ -26,7 +26,7 @@ Hooks.on("createChatMessage", (message, data, options, userId) => {
     const isNPCLoggingEnabled =  game.settings.get(MODULE_ID, "enableNPCTracking");
     let attackerId =  message.flags.pf2e.origin?.actor;
     const attackActor = (attackerId)?fromUuidSync(attackerId):null;
-    const attacker =    (attackActor)?attackActor.name:UNIDENTIFIED_ATTACKER;
+    const attacker =    (attackActor)?attackActor.name:UNIDENTIFIED_ATTACKER;       //Probably should use token.name here for NPCs (to get decorated names) - should I lose attackerId (I don't use it to render)
     let isNPC =       (attackActor?.type !== "character");
 
     if (!attackerId) {  //invalid attackerId usually indicates manually applied damage (or unarmed strikes)
@@ -67,7 +67,7 @@ Hooks.on("createChatMessage", (message, data, options, userId) => {
     const isNPCLoggingEnabled =  game.settings.get(MODULE_ID, "enableNPCTracking");
     let attackerId =  message.flags.pf2e.origin?.actor;
     const attackActor = (attackerId)?fromUuidSync(attackerId):null;
-    const attacker =    (attackActor)?attackActor.name:UNIDENTIFIED_ATTACKER;
+    const attacker =    (attackActor)?attackActor.name:UNIDENTIFIED_ATTACKER;   //Probably should use token.name here for NPCs (to get decorated names).
     let isNPC =       (attackActor?.type !== "character");
 
     if (!attackerId) {  //invalid attackerId usually indicates manually applied damage (or unarmed strikes)

--- a/scripts/formapp.js
+++ b/scripts/formapp.js
@@ -9,8 +9,11 @@ class DamageTrackerSettings extends HandlebarsApplicationMixin(ApplicationV2) {
     form: {
       handler: DamageTrackerSettings.onSubmitForm,
       closeOnSubmit: true
-    }
+    },
   };
+
+  sortKey = "totDmg";
+  isSortAsc = false;
 
   static PARTS = {
     topButtons: {template: `modules/${MODULE_ID}/templates/partials/topButtons.hbs`},
@@ -32,11 +35,14 @@ class DamageTrackerSettings extends HandlebarsApplicationMixin(ApplicationV2) {
     if(!this._listenersBound) {
       html.querySelector(".clear-tracking-button")?.addEventListener("click", this.#onClearTrackingClick.bind(this));
       html.querySelector(".clear-NPCs-button")?.addEventListener("click", this.#onClearNPCsClick.bind(this));
-      html.querySelector(".export-damage-map")?.addEventListener("click", this.#onExportDamapgeMapClick.bind(this));
-    
+      html.querySelector(".export-damage-map")?.addEventListener("click", this.#onExportDamageMapClick.bind(this));
+
+      this.#registerContentEventHandlers();
+
       // Start refresh loop - only set when listeners are initially bound 
       // i.e. don't check this every render
       if (!this._pollInterval) {
+        this.refreshContent();
         this._pollInterval = setInterval(() => {
           if (this.rendered) this.refreshContent();
         }, 3000); // 3 seconds
@@ -46,7 +52,27 @@ class DamageTrackerSettings extends HandlebarsApplicationMixin(ApplicationV2) {
 
   _getSortedActorData() {
     const dmgMap = game.settings.get(MODULE_ID, "damageMap");
-    return Object.values(dmgMap).sort((a, b) => b.totDmg - a.totDmg);
+    
+    const key = this.sortKey;
+    const asc = this.isSortAsc;
+    
+    const sortedActors = Object.values(dmgMap).sort((a, b) => {
+      let aVal = a[key];
+      let bVal = b[key];
+
+      if (aVal == null) aVal = "";
+      if (bVal == null) bVal = "";
+
+      if ((typeof aVal === "number")&& (typeof bVal === "number")) {   //numeric sort
+        return asc?aVal-bVal:bVal-aVal;
+      }
+      
+      aVal = String(aVal).toLowerCase();
+      bVal = String(bVal).toLowerCase();
+
+      return asc?aVal.localeCompare(bVal):bVal.localeCompare(aVal);
+    });
+    return sortedActors;
   }
 
   async _prepareContext(options) {
@@ -59,9 +85,9 @@ class DamageTrackerSettings extends HandlebarsApplicationMixin(ApplicationV2) {
     }
 
     return {
-      formData: {
-        actors: sortedActors
-      }
+      actors: sortedActors,
+      sortKey: this.sortKey,
+      isSortAsc: this.isSortAsc
     };  
   }
 
@@ -71,11 +97,7 @@ class DamageTrackerSettings extends HandlebarsApplicationMixin(ApplicationV2) {
         Object.entries(settings)
             .map(([key, value]) => game.settings.set(MODULE_ID, key, value))
     );
-
-  //  await this.document.update(formData.object);
-  
-}
-  
+  }
   
   //Click Handlers
    //TODO: Should I add buttons for each "heading" to allow for Sorting by listening to each button and refreshing?
@@ -94,7 +116,7 @@ class DamageTrackerSettings extends HandlebarsApplicationMixin(ApplicationV2) {
       ui.notifications.info("Damage tracking data has been cleared.");
 
       //refresh Settings page since data changed.
-      this.render(true);
+      this.refreshContent();
     }
   }
 
@@ -130,11 +152,11 @@ class DamageTrackerSettings extends HandlebarsApplicationMixin(ApplicationV2) {
       ui.notifications.info("Damage tracking data for NPCs has been cleared.");
 
       //refresh Settings page since data changed.
-      this.render(true);
+      this.refreshContent();
     }  
   }
   
- #onExportDamapgeMapClick(event) {
+ #onExportDamageMapClick(event) {
     var exportData = "Actor Name, isNPC, Max Damage Roll, Max Damage, Total Damage\n";
     const dmgMap = game.settings.get(MODULE_ID,"damageMap");
     const sortedActors = Object.values(dmgMap).sort((a,b) => b.totDmg - a.totDmg);
@@ -163,20 +185,42 @@ class DamageTrackerSettings extends HandlebarsApplicationMixin(ApplicationV2) {
     expDialog.render(true);
   }
 
+  #onSortableClick(event) { 
+    console.log(event);
+
+    const key = event.currentTarget.dataset.key;
+  
+    if (this.sortKey === key) {
+      this.isSortAsc = !this.isSortAsc; // toggle direction
+    } else {
+      this.sortKey = key;
+      this.isSortAsc = (key === "name")?true:false; // default to ascending for name, descending for everything else
+    }
+
+    this.refreshContent();
+  }
+
+  #registerContentEventHandlers() {
+    this.element?.querySelectorAll(".sortable").forEach( el => {
+      const key = el.dataset.key;
+
+      if (!key) return;
+
+      el.addEventListener("click", this.#onSortableClick.bind(this));
+    });
+  }
+
   async refreshContent() {
     const container = this.element?.querySelector(".damageTable");  //top element of tableContent.hbs
     if (!container) return;
 
-    // Prepare fresh data
-    const formData = {
-      actors: this._getSortedActorData() 
-    };
-
     // Render the partial template
-    const newHTML = await renderTemplate(DamageTrackerSettings.PARTS.content.template, { formData });
+    const newHTML = await renderTemplate(DamageTrackerSettings.PARTS.content.template, { actors: this._getSortedActorData(), sortKey: this.sortKey, isSortAsc: this.isSortAsc });
 
     // Replace the content
      container.innerHTML = newHTML;
+
+    this.#registerContentEventHandlers();
   }
 
   close() {

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -59,13 +59,6 @@ Hooks.once("init", async() => {
     default: {}
   });
 
-  await loadTemplates([
-    `modules/${MODULE_ID}/templates/partials/topButtons.hbs`,
-    `modules/${MODULE_ID}/templates/partials/tableContent.hbs`,
-    `modules/${MODULE_ID}/templates/partials/exportButton.hbs`
-  ]);
-
-  
   isDebug = game.settings.get(MODULE_ID, "isDebug");
 
   if (isDebug) console.log(LOG_PREFIX, "settings registered.");

--- a/templates/partials/PCgrouping.hbs
+++ b/templates/partials/PCgrouping.hbs
@@ -1,0 +1,6 @@
+<div style="display: flex; justify-content: center; margin-top: 1em;">
+  <label>
+    <input type="checkbox" id="groupPC" class="group-PCs"></input>
+      Move PCs to the top of the list
+  </label>
+</div>

--- a/templates/partials/tableContent.hbs
+++ b/templates/partials/tableContent.hbs
@@ -2,15 +2,31 @@
   <table class="damage-table" style="width:100%; border-collapse: collapse;">
     <thead>
       <tr>
-        <th style="border-bottom: 1px solid #ccc; text-align: left;">Name</th>
-        <th style="border-bottom: 1px solid #ccc; text-align: center;">Max Roll</th>
-        <th style="border-bottom: 1px solid #ccc; text-align: center;">Max Hit</th>
-        <th style="border-bottom: 1px solid #ccc; text-align: center;">Total Damage</th>
+          <th class="sortable" data-key="name" style="border-bottom: 1px solid #ccc; text-align: left;">Name {{log this}}
+          {{#if (eq sortKey "name")}}
+            {{#if isSortAsc}}↑{{else}}↓{{/if}}
+          {{/if}}
+        </th>
+        <th class="sortable" data-key="maxDmgRoll" style="border-bottom: 1px solid #ccc; text-align: center;">Max Roll
+          {{#if (eq sortKey "maxDmgRoll")}}
+            {{#if isSortAsc}}↑{{else}}↓{{/if}}
+          {{/if}}
+        </th>
+        <th class="sortable" data-key="maxDmg" style="border-bottom: 1px solid #ccc; text-align: center;">Max Hit
+          {{#if (eq sortKey "maxDmg")}}
+            {{#if isSortAsc}}↑{{else}}↓{{/if}}
+          {{/if}}
+        </th>
+        <th class="sortable" data-key="totDmg" style="border-bottom: 1px solid #ccc; text-align: center;">Total Damage  
+          {{#if (eq sortKey "totDmg")}}
+            {{#if isSortAsc}}↑{{else}}↓{{/if}}
+          {{/if}}
+        </th>
       </tr>
     </thead>
     <tbody>
-      {{#if formData.actors.length}}
-        {{#each formData.actors}}
+      {{#if actors.length}}
+        {{#each actors}}
           <tr>
             <td>
               {{#unless this.isNPC}}<strong>{{this.name}}</strong>{{else}}{{this.name}}{{/unless}}


### PR DESCRIPTION
Allow Sorting by columns in Details.
Allow Grouping of PCs to the top of the list.

Bugfixes/logic changes:
Use Token.name instead of Actor.Name, 
Fix bug with previous MaxDamageRoll logic (didn't clear properly since it was set twice - damageroll and then apply damage).
